### PR TITLE
Lower tracing version requirement

### DIFF
--- a/venator/Cargo.toml
+++ b/venator/Cargo.toml
@@ -12,7 +12,7 @@ keywords = ["logging", "tracing", "profiling"]
 bincode = { version = "1.3.3", default-features = false }
 serde = { version = "1.0.159", default-features = false, features = ["std", "derive"] }
 thread-id = "5.0.0"
-tracing = { version = "0.1.37", default-features = false }
+tracing = { version = "0.1.30", default-features = false }
 tracing-subscriber = { version = "0.3.16", default-features = false, features = ["std", "registry"] }
 
 [dev-dependencies]


### PR DESCRIPTION
It's not needed for venator, and rustc currently cannot update tracing due to performance regressions