### PR TITLE
Clarify OpenTelemetry in OTEL terms

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,8 +36,8 @@ cargo install venator-app
 ### Using OpenTelemetry:
 
 Configure your program's OpenTelemetry SDK to export logs and traces to
-`127.0.0.1:8362` (Venator's default listening port) and to use GRPC or HTTP with
-binary encoding.
+`127.0.0.1:8362` (Venator's default listening port) and to use `grpc` or
+`http/protobuf`.
 
 ### Using Rust Tracing:
 


### PR DESCRIPTION
The official name of the otel protocols are `grpc`, `http/protobuf`, and `http/json`, and that's what's set in e.g. `OTEL_EXPORTER_OTLP_PROTOCOL`.

I assume by "HTTP with binary encoding" the readme means `http/protobuf` but I figure it's clearer to write it out explicitly.